### PR TITLE
Add Next.js application with Hi Casi!!! page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "casi.today",
+  "version": "1.0.0",
+  "dependencies": {
+    "next": "^12.0.7",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  },
+  "scripts": {
+    "build": "next build",
+    "start": "next start"
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,7 @@
+import { AppProps } from 'next/app';
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+
+export default MyApp;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,17 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+
+class MyDocument extends Document {
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,12 @@
+import Head from 'next/head';
+
+export default function Home() {
+  return (
+    <div>
+      <Head>
+        <title>Hi Casi!!!</title>
+      </Head>
+      <div>Hi Casi!!!</div>
+    </div>
+  );
+}


### PR DESCRIPTION
Add a Next.js application with a page titled "Hi Casi!!!".

* **pages/index.js**
  - Create a new Next.js page component.
  - Import `Head` from `next/head`.
  - Add a `div` with the text "Hi Casi!!!".
  - Set the page title to "Hi Casi!!!" using `Head`.

* **package.json**
  - Add a new `package.json` file for the Next.js application.
  - Set the `name` to "casi.today".
  - Set the `version` to "1.0.0".
  - Add `next`, `react`, and `react-dom` as dependencies.
  - Add `next build` and `next start` scripts.

* **pages/_app.js**
  - Create a custom App component for Next.js.
  - Import `AppProps` from `next/app`.
  - Export a function that returns the `Component` with `pageProps`.

* **pages/_document.js**
  - Create a custom Document component for Next.js.
  - Import `Document`, `Html`, `Head`, `Main`, and `NextScript` from `next/document`.
  - Export a class that extends `Document` and overrides `render` method.
  - Return `Html` with `Head`, `Main`, and `NextScript`.

